### PR TITLE
Fix: fix properties picker for 2+ levels

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -301,7 +301,7 @@ export declare type DeepPick<T extends FilterModify<F>, F> = T extends Builtin
       {
         [K in Extract<OptionalKeys<T>, keyof F>]+?: F[K] extends never
           ? T[K]
-          : T[K] extends FilterModify<F[K]>
+          : F[K] extends object
           ? DeepPick<T[K], F[K]>
           : never;
       },
@@ -320,7 +320,7 @@ export declare type DeepPick<T extends FilterModify<F>, F> = T extends Builtin
 
 type FilterModify<T> =
   | {
-      [K in keyof T]: T[K] extends never ? any : T[K] extends object ? FilterModify<T[K]> : never;
+      [K in keyof T]+?: T[K] extends never ? any : T[K] extends object ? FilterModify<T[K]> : never;
     }
   | Array<FilterModify<T>>
   | Promise<FilterModify<T>>


### PR DESCRIPTION
Fix: fix properties picker for 2+ levels (When assigned a finder of multiple levels, this is not detected by the inspector)
Fix: Fix optional properties (DeepPick initializer fails when I assign an interface with optional props)

<img width="722" alt="Screen Shot 2020-11-05 at 5 18 51 PM" src="https://user-images.githubusercontent.com/1148415/98298427-5a8cee00-1f8c-11eb-8a72-fa4135c4f2fc.png">
